### PR TITLE
Lock dependency versions and improve build security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+min-release-age=7
+ignore-scripts=true
+save-exact=true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm ci --ignore-scripts && npm run build"
   publish = ".next"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -11,27 +11,27 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^7.2.0",
-    "@fortawesome/free-brands-svg-icons": "^7.2.0",
-    "@fortawesome/free-solid-svg-icons": "^7.2.0",
-    "@fortawesome/react-fontawesome": "^3.3.0",
-    "@videojs/react": "^10.0.0-alpha.11",
-    "fuse.js": "^7.1.0",
-    "hls.js": "^1.5.0",
-    "next": "^16.2.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@fortawesome/fontawesome-svg-core": "7.2.0",
+    "@fortawesome/free-brands-svg-icons": "7.2.0",
+    "@fortawesome/free-solid-svg-icons": "7.2.0",
+    "@fortawesome/react-fontawesome": "3.3.0",
+    "@videojs/react": "10.0.0-alpha.11",
+    "fuse.js": "7.1.0",
+    "hls.js": "1.6.15",
+    "next": "16.2.1",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
-    "@netlify/plugin-nextjs": "^5.15.9",
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "^16.2.1",
-    "tailwindcss": "^4",
-    "tsx": "^4.21.0",
-    "typescript": "^5"
+    "@netlify/plugin-nextjs": "5.15.9",
+    "@tailwindcss/postcss": "4.2.2",
+    "@types/node": "20.19.37",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "eslint": "9.39.4",
+    "eslint-config-next": "16.2.1",
+    "tailwindcss": "4.2.2",
+    "tsx": "4.21.0",
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
This PR pins all dependency versions to exact versions and improves the build process security by disabling script execution during dependency installation.

## Key Changes
- **Pinned all dependencies to exact versions** in `package.json`:
  - Removed caret (`^`) version specifiers from all dependencies and devDependencies
  - Updated several packages to their latest patch versions (e.g., `react` and `react-dom` to 19.2.4, `hls.js` to 1.6.15)
  - This ensures consistent, reproducible builds across environments

- **Added `.npmrc` configuration file** with three important settings:
  - `save-exact=true`: Ensures future npm installs will also use exact versions
  - `ignore-scripts=true`: Disables arbitrary script execution during installation for improved security
  - `min-release-age=7`: Prevents installation of very recently published versions

- **Updated Netlify build command** in `netlify.toml`:
  - Changed from `npm run build` to `npm ci --ignore-scripts && npm run build`
  - Uses `npm ci` (clean install) for more reliable CI/CD builds
  - Explicitly passes `--ignore-scripts` flag to prevent script execution

## Benefits
- **Reproducibility**: Exact versions ensure identical builds across all environments
- **Security**: Disabling npm scripts prevents potential supply chain attacks
- **Stability**: Prevents unexpected behavior from minor/patch version updates
- **CI/CD Reliability**: Using `npm ci` is the recommended approach for automated builds

https://claude.ai/code/session_017QwTEbDPGfJ6utLrhSaTjC